### PR TITLE
Update nodejs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN \
 
 RUN apt-get update && apt-get install -yq --fix-missing apt-transport-https
 RUN apt-get update && apt-get install -yq --fix-missing python-software-properties
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -yq --fix-missing nodejs
 RUN apt-get update && apt-get install -yq --fix-missing git
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If this package, is helpful to you, you can add **star** on [docker hub](https:/
 
 | LARAVEL VERSION | COMPATIBLE |
 | --------------- | ---------- |
+| 5.7             | YES        |
 | 5.6             | YES        |
 | 5.5             | YES        |
 | 5.4 and below   | not tested |
@@ -80,7 +81,7 @@ services:
 | NGINX        | >= 1.10.3  |
 | Chromedriver | >= 2.38    |
 | Chrome       | >= 66      |
-| NODEJS       | >= 6.14.2  |
+| NODEJS       | >= 8.12.0  |
 | NPM          | >= 3.10.10 |
 | YARN         | >= 1.6.0   |
 | BOWER        | >= 1.8.4   |


### PR DESCRIPTION
I've found some incompatibilities with nodejs version 6 like below:

```
Module build failed: Error: Missing binding /builds/inpin/landing/node_modules/node-sass/vendor/linux-x64-48/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 6.x

Found bindings for the following environments:
  - Linux 64-bit with Node.js 8.x
```

Then I've updated nodejs version to 8 and everything runs correctly.