### PR TITLE
Link default php to php7.2 and install php-geos lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 MAINTAINER Chilio 
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,11 @@ RUN apt-get update && apt-get install -yq --fix-missing \
     php-geos \
     php-xdebug php-imagick imagemagick nginx
 
-RUN ln -nfs /usr/bin/php7.2 php
+RUN update-alternatives --set php /usr/bin/php7.2
+RUN update-alternatives --set phar /usr/bin/phar7.2
+RUN update-alternatives --set phar.phar /usr/bin/phar.phar7.2
+# RUN update-alternatives --set phpize /usr/bin/phpize7.2
+# RUN update-alternatives --set php-config /usr/bin/php-config7.2
 RUN apt-get update && apt-get install -yq --fix-missing mc lynx mysql-client bzip2 make g++
 
 # Install Redis, Memcached, Beanstalk

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,10 @@ RUN apt-get update && apt-get install -yq --fix-missing \
     php-ds \
     php-sass \
     php-lua \
+    php-geos \
     php-xdebug php-imagick imagemagick nginx
 
-
+RUN ln -nfs /usr/bin/php7.2 php
 RUN apt-get update && apt-get install -yq --fix-missing mc lynx mysql-client bzip2 make g++
 
 # Install Redis, Memcached, Beanstalk

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN \
 
 RUN apt-get update && apt-get install -yq --fix-missing apt-transport-https
 RUN apt-get update && apt-get install -yq --fix-missing python-software-properties
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -yq --fix-missing nodejs
 RUN apt-get update && apt-get install -yq --fix-missing git
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,6 @@ RUN \
   && apt-get -yqq update && apt-get -yqq install google-chrome-stable x11vnc
 
 RUN apt-get update && apt-get install -yq --fix-missing apt-transport-https
-RUN apt-get update && apt-get install -yq --fix-missing python-software-properties
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -yq --fix-missing nodejs
 RUN apt-get update && apt-get install -yq --fix-missing git

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If this package, is helpful to you, you can add **star** on [docker hub](https:/
 
 | LARAVEL VERSION | COMPATIBLE |
 | --------------- | ---------- |
+| 5.7             | YES        |
 | 5.6             | YES        |
 | 5.5             | YES        |
 | 5.4 and below   | not tested |
@@ -80,7 +81,7 @@ services:
 | NGINX        | >= 1.10.3  |
 | Chromedriver | >= 2.38    |
 | Chrome       | >= 66      |
-| NODEJS       | >= 6.14.2  |
+| NODEJS       | >= 8.12.0  |
 | NPM          | >= 3.10.10 |
 | YARN         | >= 1.6.0   |
 | BOWER        | >= 1.8.4   |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ However, in case of problems, according to this **documentation**, you might nee
 
 
 ### **Changelog**
+- 2018-10-24 - Install php-geos and link defualt `php` command to `php7.2`
 - 2018-10-09 - Updated to nodejs v8
 - 2018-10-06 - Latest chromedriver compatibility updated
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ However, in case of problems, according to this **documentation**, you might nee
 
 
 ### **Changelog**
-- 2018-10-24 - Install php-geos and link defualt `php` command to `php7.2`
+- 2018-10-24 - Update to ubuntu:bionic (18.04), Install php-geos and link defualt `php` command to `php7.2`
 - 2018-10-09 - Updated to nodejs v8
 - 2018-10-06 - Latest chromedriver compatibility updated
 


### PR DESCRIPTION
It seems currently the default `php` command currently lead us to php7.3.

I've installed php-geos library then we are able to use its useful functionality.

