### PR TITLE
Add creation of storage link to configure script

### DIFF
--- a/commands/configure-laravel.sh
+++ b/commands/configure-laravel.sh
@@ -4,6 +4,7 @@ chmod -R 775 storage
 chmod 775 bootstrap/cache
 chown -R www-data ./
 php artisan key:generate
+php artisan storage:link
 php artisan migrate:fresh --seed
 chrome-system-check
 sleep 10s


### PR DESCRIPTION
It seems like setting up the storage link is a default part of the laravel setup process.